### PR TITLE
fix: prefix skills path with ./ in plugin manifests

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,5 +6,5 @@
     "name": "Microsoft",
     "url": "https://github.com/MicrosoftDocs/agent-skills"
   },
-  "skills": "skills/"
+  "skills": "./skills/"
 }

--- a/plugin.json
+++ b/plugin.json
@@ -6,5 +6,5 @@
     "name": "Microsoft",
     "url": "https://github.com/MicrosoftDocs/agent-skills"
   },
-  "skills": "skills/"
+  "skills": "./skills/"
 }


### PR DESCRIPTION
Fixes #64

Both `plugin.json` and `.claude-plugin/plugin.json` had `"skills": "skills/"` but the plugin-manifest schema requires the path to start with `./`. The `.codex-plugin/plugin.json` already uses the correct `"./skills/"` form.

**Changes:**
- `plugin.json`: `"skills/""` → `"./skills/""`
- `.claude-plugin/plugin.json`: `"skills/""` → `"./skills/""`

Verified the fix passes `claude plugin validate` locally.